### PR TITLE
Update artifact.yml

### DIFF
--- a/.github/workflows/artifact.yml
+++ b/.github/workflows/artifact.yml
@@ -14,7 +14,7 @@ jobs:
       run: echo "Hello, world!" > hello.txt
 
     - name: Archive text file
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v3
       with:
         name: hello-artifact
         path: hello.txt


### PR DESCRIPTION
The version v2 is deprecated and update with v3.
The version v2 is causing the action workflow to fail with the error 'Error: This request has been automatically failed because it uses a deprecated version of `actions/upload-artifact: v2'